### PR TITLE
FIX: creating LoginForm from Authenticator

### DIFF
--- a/src/Authenticators/SAMLAuthenticator.php
+++ b/src/Authenticators/SAMLAuthenticator.php
@@ -52,7 +52,7 @@ class SAMLAuthenticator extends MemberAuthenticator
      */
     public static function get_login_form(Controller $controller)
     {
-        return new SAMLLoginForm($controller, 'LoginForm');
+        return new SAMLLoginForm($controller, self::class, 'LoginForm');
     }
 
     /**

--- a/src/Authenticators/SAMLLoginForm.php
+++ b/src/Authenticators/SAMLLoginForm.php
@@ -42,7 +42,7 @@ class SAMLLoginForm extends LoginForm
      * Constructor
      *
      * @param RequestHandler $controller
-     * @param string $authenticatorClass
+     * @param string $authenticatorClass @deprecated this argument is not used, can be removed in next major release
      * @param string $name method on the $controller
      */
     public function __construct(RequestHandler $controller, $authenticatorClass, $name)


### PR DESCRIPTION
- missing arguments and arguments mismatch when creating SamlLoginForm from SamlAuthenticator
- adding a phpdoc note about unused constructor argument