### PR TITLE
Add: possibility to use additional get-query parameters to SAML Request

### DIFF
--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -36,6 +36,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
   - [Allow insecure linking-by-email](#allow-insecure-linking-by-email)
   - [Adjust the requested AuthN contexts](#adjust-the-requested-authn-contexts)
   - [Create your own SAML configuration for completely custom settings](#create-your-own-saml-configuration-for-completely-custom-settings)
+  - [Additional GET Query Params for SAML](#additional-get-query-params-for-saml)
 - [Resources](#resources)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -378,6 +379,18 @@ class MySAMLConfiguration
 
 See the [advanced\_settings/\_example.php](https://github.com/onelogin/php-saml/blob/master/advanced_settings_example.php)
 for the advanced settings.
+
+### Additional GET Query Params for SAML
+example:
+```yaml
+SilverStripe\SAML\Services\SAMLConfiguration:
+  additional_get_query_params:
+    someGetQueryParameter: 'value'
+    AnotherParameter: 'differentValue'
+```
+
+this configuration allows you to add two GET query parameters to endpoint request URL:
+`https://your-idp.com/singleSignOnService/saml2?someGetQueryParameter=value&AnotherParameter=differentValue&SAMLRequest=XYZ....`
 
 ## Resources
 

--- a/src/Helpers/SAMLHelper.php
+++ b/src/Helpers/SAMLHelper.php
@@ -72,8 +72,10 @@ class SAMLHelper
             $request->getSession()->save($request);
         }
 
+        $additionalGetQueryParams = $this->getAdditionalGETQueryParameters();
+
         try {
-            $auth->login(Director::absoluteBaseURL() . 'saml/');
+            $auth->login(Director::absoluteBaseURL() . 'saml/', $additionalGetQueryParams);
         } catch (Exception $e) {
             /** @var LoggerInterface $logger */
             $logger = Injector::inst()->get(LoggerInterface::class);
@@ -124,5 +126,18 @@ class SAMLHelper
         $hex_guid_to_guid_str .= '-' . substr($hex_guid, 16, 4);
         $hex_guid_to_guid_str .= '-' . substr($hex_guid, 20);
         return strtoupper($hex_guid_to_guid_str);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAdditionalGETQueryParameters()
+    {
+        $additionalGetQueryParams = $this->SAMLConfService->config()->get('additional_get_query_params');
+        if (!is_array($additionalGetQueryParams)) {
+            $additionalGetQueryParams = [];
+        }
+
+        return $additionalGetQueryParams;
     }
 }

--- a/src/Services/SAMLConfiguration.php
+++ b/src/Services/SAMLConfiguration.php
@@ -85,6 +85,14 @@ class SAMLConfiguration
     private static $expose_guid_as_attribute = false;
 
     /**
+     * @config
+     * @example ['GET Query Parameter Name' => 'Parameter Value', ... ]
+     *
+     * @var string[]
+     */
+    private static $additional_get_query_params = [];
+
+    /**
      * @return array
      */
     public function asArray()


### PR DESCRIPTION
This configuration option allow use additional simple query parameters in Authentication request URL (handy for custom IdP configurations like helping with Home Realm Discovery and others)

