### PR TITLE
Feat(Attribute Mapping): Allow the use of opt in GUID/nameid as attribute.

### DIFF
--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -153,6 +153,11 @@ class SAMLController extends Controller
 
         $attributes = $auth->getAttributes();
 
+        // Allows setups that map GUID (email format) to email {@see SAMLConfiguration::$expose_guid_as_attribute}.
+        if (Config::inst()->get(SAMLConfiguration::class, 'expose_guid_as_attribute')) {
+            $attributes['GUID'][0] = $guid;
+        }
+
         $fieldToClaimMap = array_flip(Member::config()->claims_field_mappings);
 
         // Write a rudimentary member with basic fields on every login, so that we at least have something

--- a/src/Services/SAMLConfiguration.php
+++ b/src/Services/SAMLConfiguration.php
@@ -73,6 +73,18 @@ class SAMLConfiguration
     private static $allow_insecure_email_linking = false;
 
     /**
+     * @config
+     * @var bool Decide if GUID should be exposed as an attribute mappable using `GUID` as the claim. This is a feature
+     * that is found in other SAML libraries but in an ideal world should not be utilised in favour of the IdP offering
+     * the nameid data as another "more stable" attribute.
+     * 
+     * Note that this data will be effected by:
+     *  - The expect_binary_nameid configuration value
+     *  - The extension point `updateGuid` on SAMLController
+     */
+    private static $expose_guid_as_attribute = false;
+
+    /**
      * @return array
      */
     public function asArray()


### PR DESCRIPTION
This would be great for our use case, We are happy to work out a hack using the extension point if that is deemed more ideal.

Weird use case but I've seen it used before eg. [MOODLE's main SAML authentication plugin](https://github.com/catalyst/moodle-auth_saml2/pull/158) explains it well.

Ideally this sort of thing gets dealt with on the IdP side but they don't always want to work with you 😄 