### PR TITLE
Refactor: More extensible NameID validation.

### DIFF
--- a/_config/saml.yml
+++ b/_config/saml.yml
@@ -16,6 +16,10 @@ SilverStripe\Core\Injector\Injector:
 SilverStripe\SAML\Authenticators\SAMLAuthenticator:
   name: "SAML"
 
+SilverStripe\SAML\Helpers\SAMLHelper:
+  extensions:
+    - SilverStripe\SAML\Extensions\GUIDNameIDValidationExtension
+
 SilverStripe\SAML\Services\SAMLConfiguration:
   strict: true
   debug: false

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -141,7 +141,7 @@ class SAMLController extends Controller
             $guid = $auth->getNameId();
         }
 
-        if (!$helper->validGuid($guid)) {
+        if (!$helper->validateNameID($guid, $auth->getNameIdFormat())) {
             $errorMessage = "Not a valid GUID '{$guid}' received from server.";
             $this->getLogger()->error($errorMessage);
             $this->getForm()->sessionMessage($errorMessage, ValidationResult::TYPE_ERROR);

--- a/src/Extensions/GUIDNameIDValidationExtension.php
+++ b/src/Extensions/GUIDNameIDValidationExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\SAML\Extensions;
+
+use SilverStripe\Core\Extension;
+
+/**
+ * Class GUIDNameIDValidationExtension
+ * 
+ * Validates a NameID in GUID format.
+ */
+class GUIDNameIDValidationExtension extends Extension
+{
+    public function updateNameIDValidation(string $nameID, string $nameIDFormat): bool
+    {
+        if (preg_match('/^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}?$/i', $nameID)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Services/SAMLConfiguration.php
+++ b/src/Services/SAMLConfiguration.php
@@ -85,6 +85,19 @@ class SAMLConfiguration
     private static $expose_guid_as_attribute = false;
 
     /**
+     * @config
+     * @var bool Decide if a SAMLResponse's nameid should be validated.
+     * 
+     * By default validation consists of two steps:
+     *  1. Will the nameID fit in the allocated varchar size of the `GUID` field on Member? (This disregards this config and always happens)
+     *  1. Is the nameID in a GUID pattern?
+     * 
+     * You can add different methods of validation via SAMLHelper's `updateNameIDValidation` extension point.
+     * An example can be found in {@see EmailNameIDValidationExtension}.
+     */
+    private static $validate_nameid = false;
+
+    /**
      * @return array
      */
     public function asArray()

--- a/tests/php/Helpers/SAMLHelperTest.php
+++ b/tests/php/Helpers/SAMLHelperTest.php
@@ -4,6 +4,8 @@ namespace SilverStripe\SAML\Tests\Helpers;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\SAML\Helpers\SAMLHelper;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\SAML\Services\SAMLConfiguration;
 
 class SAMLHelperTest extends SapphireTest
 {
@@ -14,7 +16,8 @@ class SAMLHelperTest extends SapphireTest
      */
     public function testValidGuid($guid, $expected)
     {
-        $result = SAMLHelper::singleton()->validGuid($guid);
+        Config::modify()->set(SAMLConfiguration::class, 'validate_nameid', true);
+        $result = SAMLHelper::singleton()->validateNameID($guid, 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified');
         $this->assertSame($expected, $result);
     }
 
@@ -31,6 +34,18 @@ class SAMLHelperTest extends SapphireTest
             ['A98C5A1E-4808-96FA-6F409E799937', false],
             ['foobar', false],
         ];
+    }
+
+    /**
+     * @testdox A long NameID that would exceed the max of a Member's GUID field should fail validation.
+     */
+    public function testLongNameIDFails()
+    {
+        $result = SAMLHelper::singleton()->validateNameID(
+            'my-excessively-long-nameid-which-is-quite-ridiculous', // 52 chars
+            'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+        );
+        $this->assertFalse($result);
     }
 
     public function testBinToStrGuid()


### PR DESCRIPTION
In summary:
1. NameID is now always validated to fit within `Member`'s `GUID` field.
2. Further validation is disabled by default behind `SAMLConfiguration`'s `validate_nameid`.
3. If `validate_nameid` is enabled validation will now be done via extensions.
4. A GUID Validation extension is registered by default and only requires `validate_nameid` to be set to true to use.
5. Docs are updated.
6. Tests are updated to reflect new config flag and test the length validation.

I'm still of the opinion that GUID (or any) validation by default is a little out of place, When I tested the following with Azure AD it used user.userprinciplename with Email format by default. It might be a nice middle-ground to at least have something a little more generic and extensible. ADFS is too dinosaur and mirosofty for me to even think about 😁. More than happy to enable the validation by default if wanted.

Is there a way I can grab a DBField's size (arguments) without creating a singleton? Grabbing it from config or via DOschema sounds neater but I couldn't find the right API.