### PR TITLE
Support for Silverstripe 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": ">=7.4",
-        "silverstripe/framework": "^4@dev",
-        "silverstripe/cms": "^4@dev",
+        "silverstripe/framework": "^5",
+        "silverstripe/cms": "^5",
         "onelogin/php-saml": "^4.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Update the required CMS version to be `^5`, it is tested out working well on a project which use SAML module and CMS 5.