### PR TITLE
Update attributes extend method

### DIFF
--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -162,6 +162,8 @@ class SAMLController extends Controller
             $attributes['GUID'][0] = $guid;
         }
 
+        $this->extend('updateAttributes', $attributes);
+
         $fieldToClaimMap = array_flip(Member::config()->claims_field_mappings);
 
         // Write a rudimentary member with basic fields on every login, so that we at least have something

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -153,8 +153,6 @@ class SAMLController extends Controller
             return $this->getRedirect();
         }
 
-        $this->extend('updateGuid', $guid);
-
         $attributes = $auth->getAttributes();
 
         // Allows setups that map GUID (email format) to email {@see SAMLConfiguration::$expose_guid_as_attribute}.
@@ -163,6 +161,7 @@ class SAMLController extends Controller
         }
 
         $this->extend('updateAttributes', $attributes);
+        $this->extend('updateGuid', $guid);
 
         $fieldToClaimMap = array_flip(Member::config()->claims_field_mappings);
 

--- a/src/Helpers/SAMLHelper.php
+++ b/src/Helpers/SAMLHelper.php
@@ -124,7 +124,7 @@ class SAMLHelper
             $hex_guid_to_guid_str .= substr($hex_guid, 16 - 2 * $k, 2);
         }
         $hex_guid_to_guid_str .= '-' . substr($hex_guid, 16, 4);
-        $hex_guid_to_guid_str .= '-' . substr($hex_guid, 20);
+        $hex_guid_to_guid_str .= '-' . substr($hex_guid, 20, 12);
         return strtoupper($hex_guid_to_guid_str);
     }
 

--- a/tests/php/Helpers/SAMLHelperTest.php
+++ b/tests/php/Helpers/SAMLHelperTest.php
@@ -36,6 +36,6 @@ class SAMLHelperTest extends SapphireTest
     public function testBinToStrGuid()
     {
         $result = SAMLHelper::singleton()->binToStrGuid('thequ!ckbrownf0xjumpsov3rthel4zyd06');
-        $this->assertSame('71656874-2175-6B63-6272-6F776E6630786A756D70736F7633727468656C347A79643036', $result);
+        $this->assertSame('71656874-2175-6B63-6272-6F776E663078', $result);
     }
 }


### PR DESCRIPTION
### changes
- Add a new hook called `updateAttributes` to update the $attributes  
- Limit the last chars to 12 on GUID to fix the validation error under `validGuid` function checking this  preg_match `/^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}?$/i`. According to this, the last chars should be 12

Please create a new tag after this and merge this to the master as well. 