### PR TITLE
Don't use singleton for getForm

### DIFF
--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -339,6 +339,6 @@ class SAMLController extends Controller
      */
     public function getForm()
     {
-        return Injector::inst()->get(SAMLLoginForm::class, true, [$this, SAMLAuthenticator::class, 'LoginForm']);
+        return Injector::inst()->get(SAMLLoginForm::class, false, [$this, SAMLAuthenticator::class, 'LoginForm']);
     }
 }

--- a/tests/php/Control/SAMLControllerTest.php
+++ b/tests/php/Control/SAMLControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\SAML\Tests\Control;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SAML\Control\SAMLController;
+
+class SAMLControllerTest extends SapphireTest
+{
+    public function testGetForm(): void
+    {
+        $controller = new SAMLController();
+
+        $form = $controller->getForm();
+
+        $this->assertNotNull($form);
+    }
+}


### PR DESCRIPTION
When using Injector to create a singleton constructor arguments are ignored. This causes getForm to fail as SAMLLoginForm requires constructor arguments.

See the docs for Injector get https://github.com/silverstripe/silverstripe-framework/blob/53c0147f112a011f8cbdfb964a92dc4eb81a8b7f/src/Core/Injector/Injector.php#L977

