### PR TITLE
FIX Don't use singleton for getForm

### DIFF
--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -348,6 +348,6 @@ class SAMLController extends Controller
      */
     public function getForm()
     {
-        return Injector::inst()->get(SAMLLoginForm::class, true, [$this, SAMLAuthenticator::class, 'LoginForm']);
+        return Injector::inst()->get(SAMLLoginForm::class, false, [$this, SAMLAuthenticator::class, 'LoginForm']);
     }
 }

--- a/tests/php/Control/SAMLControllerTest.php
+++ b/tests/php/Control/SAMLControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\SAML\Tests\Control;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SAML\Control\SAMLController;
+
+class SAMLControllerTest extends SapphireTest
+{
+    public function testGetForm(): void
+    {
+        $controller = new SAMLController();
+
+        $form = $controller->getForm();
+
+        $this->assertNotNull($form);
+    }
+}


### PR DESCRIPTION
- Identical fix from [main](https://github.com/silverstripe/silverstripe-saml/commit/3f211b529a73cd8a3a15e4cfe5849adcf399da9a) branch. Applying fix on Silverstripe 4 branch to prevent the same exception from occuring.

- When using Injector to create a singleton constructor arguments are ignored. This causes getForm to fail as SAMLLoginForm requires constructor arguments.