### PR TITLE
Include features currently exclusive to CMS 4 support branch

### DIFF
--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -73,9 +73,12 @@ class SAMLController extends Controller
         $uniqueErrorId = uniqid('SAML-');
 
         // Force php-saml module to use the current absolute base URL (e.g. https://www.example.com/saml). This avoids
-        // errors that we otherwise get when having a multi-directory ACS URL like /saml/acs).
+        // errors that we otherwise get when having a multi-directory ACS  URL (like /saml/acs).
         // See https://github.com/onelogin/php-saml/issues/249
-        Utils::setBaseURL(Controller::join_links($auth->getSettings()->getSPData()['entityId'], 'saml'));
+        Utils::setBaseURL(Controller::join_links(Director::absoluteBaseURL(), 'saml'));
+
+        // Hook point to allow extensions to further modify or unset any of the above base url coersion
+        $this->extend('onBeforeAcs', $uniqueErrorId);
 
         // Attempt to process the SAML response. If there are errors during this, log them and redirect to the generic
         // error page. Note: This does not necessarily include all SAML errors (e.g. we still need to confirm if the

--- a/src/Services/SAMLConfiguration.php
+++ b/src/Services/SAMLConfiguration.php
@@ -151,6 +151,7 @@ class SAMLConfiguration
         $spEntityId = Injector::inst()->convertServiceProperty($sp['entityId']);
         $extraAcsBaseUrl = (array)$config->get('extra_acs_base');
         $currentBaseUrl = Director::absoluteBaseURL();
+        $count = count($extraAcsBaseUrl);
         $acsBaseUrl = in_array($currentBaseUrl, $extraAcsBaseUrl) ? $currentBaseUrl : $spEntityId;
 
         $spX509Cert = Injector::inst()->convertServiceProperty($sp['x509cert']);

--- a/tests/php/Services/SAMLConfigurationTest.php
+++ b/tests/php/Services/SAMLConfigurationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SilverStripe\SAML\Tests\Services;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SAML\Services\SAMLConfiguration;
+
+class SAMLConfigurationTest extends SapphireTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $config = Config::modify();
+        $config->set(Director::class, 'alternate_base_url', 'https://running.test');
+
+        $config->set(SAMLConfiguration::class, 'extra_acs_base', [
+            'https://example.running.test/'
+        ]);
+
+        $config->set(SAMLConfiguration::class, 'SP', [
+            'entityId' => "https://running.test",
+            'privateKey' => __DIR__ . '/fakeCertificate.pem',
+            'x509cert' => __DIR__ . '/fakeCertificate.pem',
+        ]);
+        $config->set(SAMLConfiguration::class, 'IdP', [
+            'entityId' => "idp.example.com",
+            'singleSignOnService' => "https://idp.example.com/test/saml2",
+            'x509cert' => __DIR__ . '/fakeCertificate.pem',
+        ]);
+
+        $config->set(SAMLConfiguration::class, 'strict', true);
+        $config->set(SAMLConfiguration::class, 'debug', false);
+        $config->set(SAMLConfiguration::class, 'Security', [
+            'signatureAlgorithm' => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        ]);
+    }
+
+    public function provideBaseUrls(): array
+    {
+        return [
+            [
+                null,
+                'https://running.test/saml/acs',
+                'SP.EntityId should be used by default'
+            ],
+            [
+                'https://example.running.test/',
+                'https://example.running.test/saml/acs',
+                'Extra ACS should work when the loaded (or specified) domain matches'
+            ],
+            [
+                'https://not-legit.running.test/',
+                'https://running.test/saml/acs',
+                'Unlisted ACS base should result in the SP.EntityId being used instead',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBaseUrls
+     *
+     * @param string $baseUrl
+     * @param string $expectedOut
+     * @return void
+     */
+    public function testAcsBaseIsSetCorrectly($baseUrl, $expectedOut, $message)
+    {
+        if (isset($baseUrl)) {
+            Config::modify()->set(Director::class, 'alternate_base_url', $baseUrl);
+        }
+        $samlConfig = (new SAMLConfiguration())->asArray();
+        $this->assertSame(
+            $expectedOut,
+            $samlConfig['sp']['assertionConsumerService']['url'],
+            $message
+        );
+    }
+}


### PR DESCRIPTION
The ability to set alternative ACS domains was submitted to the CMS 4 support branch with the intention for it to be merged up. However the mainenance has diverged the branches, so this is a cherry-pick for feature parity instead.