### PR TITLE
NEW Allow silverstripe/errorpage to static publish

### DIFF
--- a/_config/errorpage.yml
+++ b/_config/errorpage.yml
@@ -1,0 +1,8 @@
+---
+Name: static-error-page
+Only:
+  moduleexists: silverstripe/errorpage
+---
+SilverStripe\ErrorPage\ErrorPage:
+  extensions:
+    - SilverStripe\SAML\Extensions\ErrorPageStaticPublish

--- a/src/Extensions/ErrorPageStaticPublish.php
+++ b/src/Extensions/ErrorPageStaticPublish.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\SAML\Extensions;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\SAML\Middleware\SAMLMiddleware;
+
+class ErrorPageStaticPublish extends DataExtension
+{
+    private ?bool $originallyEnabled = null;
+
+    public function onBeforeStaticWrite()
+    {
+        $config = SAMLMiddleware::config();
+        $this->originallyEnabled = $config->get('enabled');
+        $config->set('enabled', false);
+    }
+
+    public function onAfterStaticWrite()
+    {
+        SAMLMiddleware::config()->set('enabled', $this->originallyEnabled);
+    }
+}


### PR DESCRIPTION
When using the error page module to create custom content error pages within the CMS (for e.g. HTTP 404 & 500) the default is to also static publish these files so the web server can reference them directly. This requires an unauthenticated execution of the controller in a mocked request in order to get all the page HTML without revealing any user based customised data that may be present. SAMLMiddleware will currently redirect this request to the IdP for authentication when enabled, essentially preventing error pages from being published, ever (in the default configuration).

Hooks to customise the environment before dispatching the mocked request to the error page controller have recently been added to the ErrorPage, allowing us to disable the middleware & re-set it after the mock request completes. We can apply this via config only if the module exists.

Resolves #32 