### PR TITLE
Remove redundant CMS 3 authenticator interface code

### DIFF
--- a/src/Authenticators/SAMLAuthenticator.php
+++ b/src/Authenticators/SAMLAuthenticator.php
@@ -34,28 +34,6 @@ use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 class SAMLAuthenticator extends MemberAuthenticator
 {
     /**
-     * @var string
-     */
-    private $name = 'SAML';
-
-    /**
-     * @return string
-     */
-    public static function get_name()
-    {
-        return Config::inst()->get(self::class, 'name');
-    }
-
-    /**
-     * @param Controller $controller
-     * @return SAMLLoginForm
-     */
-    public static function get_login_form(Controller $controller)
-    {
-        return new SAMLLoginForm($controller, self::class, 'LoginForm');
-    }
-
-    /**
      * This method does nothing, as all authentication via SAML is handled via HTTP redirects (similar to OAuth) which
      * are not supported by the Authenticator system. Authentication via SAML is only triggered when a user hits the
      * SAMLController->acs() endpoint when returning from the identity provider.


### PR DESCRIPTION
SilverStripe 2 & 3 used an abstract class to as an interface to implement authenticators. Usable implementors could identify themselves via get_name and a designate a log in Form class via get_login_form

https://github.com/silverstripe/silverstripe-framework/blob/3/security/Authenticator.php#L51
https://github.com/silverstripe/silverstripe-framework/blob/3/security/Authenticator.php#L77

Silverstripe CMS 4 completely refactored the authentication API and introduced an Authenticator interface defining a method getLoginHandler. There is also a LoginForm abstract class that implements a method getAuthenticatorName for the associated Authenticator.

https://github.com/silverstripe/silverstripe-framework/blob/4/src/Security/Authenticator.php#L73
https://github.com/silverstripe/silverstripe-framework/blob/4/src/Security/MemberAuthenticator/LoginHandler.php#L94
https://github.com/silverstripe/silverstripe-framework/blob/4/src/Security/LoginForm.php#L71

The old static methods removed in this commit are no longer required, and the private property is not referred to anywhere within the class. I suspect it might be a typographical omission where it was supposed to be private static $name; a "default" for the config referred to in get_name (also removed).
