### PR TITLE
Update coding standards to PSR-12

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="SilverStripe">
-    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+<ruleset name="SilverstripeSaml">
+    <description>PSR-12 with exceptions for Silverstripe CMS coding conventions used in this SAML module</description>
 
     <file>src</file>
     <file>tests</file>
 
-    <!-- base rules are PSR-2 -->
-    <rule ref="PSR2">
-        <!-- Current exclusions -->
+    <rule ref="PSR12">
+        <!-- Silverstripe convention uses CapitalCase for template targetted methods (see SAMLLoginHandler::Link) -->
         <exclude name="PSR1.Methods.CamelCapsMethodName" />
-        <exclude name="PSR2.Classes.PropertyDeclaration" />
-        <exclude name="Generic.Files.LineLength.TooLong" />
     </rule>
 </ruleset>
-

--- a/src/Control/SAMLController.php
+++ b/src/Control/SAMLController.php
@@ -3,9 +3,6 @@
 namespace SilverStripe\SAML\Control;
 
 use Exception;
-
-use function gmmktime;
-
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Constants;
 use OneLogin\Saml2\Utils;
@@ -26,6 +23,7 @@ use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
+use function gmmktime;
 use function uniqid;
 
 /**

--- a/src/Middleware/SAMLMiddleware.php
+++ b/src/Middleware/SAMLMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverStripe\SAML\Middleware;
 
 use SilverStripe\Control\Controller;


### PR DESCRIPTION
PSR-2 is outdated, and some of the exceptions in the config are outdated. A minor shuffle of "header" `use` statements was required to comply with updated standard XML. Updated exception comment to explain _why_ it is there.