### PR TITLE
Refactor ACS method for maintenance ease

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,11 @@
     },
     "autoload": {
         "psr-4": {
-            "SilverStripe\\SAML\\": "src/",
+            "SilverStripe\\SAML\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "SilverStripe\\SAML\\Tests\\": "tests/php/"
         }
     },

--- a/src/Exceptions/AcsFailure.php
+++ b/src/Exceptions/AcsFailure.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\SAML\Exceptions;
+
+use RuntimeException;
+
+/**
+ * This is used a message carrying interface, rather than a "proper" exception (to halt execution)
+ * A way to short out of ACS and centralise logging & user message display functionality without passing around details
+ * like unique ID, etc. It also provides an easy way for extensions that utilise the ACS hook points to both log and
+ * trigger authentication failures.
+ *
+ * @see SilverStripe\SAML\Control\SAMLController::acs
+ */
+class AcsFailure extends RuntimeException
+{
+}

--- a/src/Helpers/SAMLHelper.php
+++ b/src/Helpers/SAMLHelper.php
@@ -40,7 +40,7 @@ class SAMLHelper
     /**
      * @return Auth
      */
-    public function getSAMLauth()
+    public function getSAMLauth(): Auth
     {
         $samlConfig = $this->SAMLConfService->asArray();
         return new Auth($samlConfig);

--- a/tests/php/Control/SAMLControllerTest.php
+++ b/tests/php/Control/SAMLControllerTest.php
@@ -88,6 +88,11 @@ class SAMLControllerTest extends SapphireTest
         $session = $this->createStub(Session::class);
         $request->method('getSession')->willReturn($session);
         $session->method('get')->with('BackURL')->willReturn('https://examle.com/another-site');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('alert')->with(
+            'Potential after log in redirect attack via session BackURL: https://examle.com/another-site'
+        );
+        Injector::inst()->registerService($logger, LoggerInterface::class);
         $redirectResponse = $this->invokeMethodOnSAMLController('getRedirect', $request);
         $this->assertSame(302, $redirectResponse->getStatusCode());
         $this->assertSame(self::BASE, $redirectResponse->getHeader('location'));
@@ -95,7 +100,7 @@ class SAMLControllerTest extends SapphireTest
 
     public function testGetRedirectWithSecurityDefault()
     {
-        $logIn = '/default/log-in';
+        $logIn = '/default/logged-in';
         Security::config()->set('default_login_dest', $logIn);
         $redirectResponse = $this->invokeMethodOnSAMLController('getRedirect');
         $this->assertSame(302, $redirectResponse->getStatusCode());

--- a/tests/php/Services/SAMLConfigurationTest.php
+++ b/tests/php/Services/SAMLConfigurationTest.php
@@ -127,8 +127,7 @@ class SAMLConfigurationTest extends SapphireTest
         );
         $this->assertArrayNotHasKey('singleLogoutService', $output['idp']);
 
-        foreach (
-            [
+        foreach ([
                 'nameIdEncrypted',
                 'authnRequestsSigned',
                 'logoutRequestSigned',


### PR DESCRIPTION
The ACS method was long, and lots of branching statements, and failed or logged from various places - which made it difficult to keep track of and thus maintain, particularly when one is wishing to add more features.

The recently added tests allow us the confidence to change this.

The majority of work has been focused around separating the distinct steps of the logging in process into encapsulated functions. This reduces the branching statements and allows for an easier read - both in the ACS method and the smaller auxiliary functions.

Authentication failures are now handled via exception, which both immediately halts further execution regarding log in processing and centralises the logging & form message output.

Other little tidy-ups have taken place regarding e.g. converting getter function multiple calls in the same method to use variables instead.