### PR TITLE
SS5 - 3.x release - Editable SAMLConfiguration Security config

### DIFF
--- a/_config/saml.yml
+++ b/_config/saml.yml
@@ -25,9 +25,18 @@ SilverStripe\SAML\Services\SAMLConfiguration:
   validate_nameid_as_guid: true
   allow_insecure_email_linking: false
   Security:
+    nameIdEncrypted: true
+    authnRequestsSigned: true
+    logoutRequestSigned: true
+    logoutResponseSigned: true
+    signMetadata: false
+    wantMessagesSigned: false
+    wantAssertionsSigned: true
+    wantNameIdEncrypted: false
     # Algorithm that the toolkit will use on signing process. Options:
     #  - 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
     #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
     #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
     signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    wantXMLValidation: true

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -35,6 +35,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
   - [Allow insecure linking-by-email](#allow-insecure-linking-by-email)
   - [Adjust the requested AuthN contexts](#adjust-the-requested-authn-contexts)
   - [Allow authentication with alternative domains (e.g. subdomains)](#allow-authentication-with-alternative-domains-eg-subdomains)
+  - [Customise SAML configuration Security config](#customise-saml-configuration-security-config)
   - [Create your own SAML configuration for completely custom settings](#create-your-own-saml-configuration-for-completely-custom-settings)
   - [Additional GET Query Params for SAML](#additional-get-query-params-for-saml)
 - [Resources](#resources)
@@ -349,6 +350,25 @@ SilverStripe\SAML\Services\SAMLConfiguration:
   extra_acs_base:
     - https://app.example.com
     - https://docs.example.com
+```
+
+### Customise SAML configuration Security config
+
+You can customise all the SAML Configuration Security config options except for `requestedAuthnContext` which is handled by the [`authn_contexts`](#adjust-the-requested-authn-contexts) (see above). 
+
+```yaml
+SilverStripe\SAML\Services\SAMLConfiguration:
+  Security:
+    nameIdEncrypted: true
+    authnRequestsSigned: true
+    logoutRequestSigned: true
+    logoutResponseSigned: true
+    signMetadata: false
+    wantMessagesSigned: false
+    wantAssertionsSigned: true
+    wantNameIdEncrypted: false
+    signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    wantXMLValidation: true
 ```
 
 ### Create your own SAML configuration for completely custom settings

--- a/src/Services/SAMLConfiguration.php
+++ b/src/Services/SAMLConfiguration.php
@@ -51,7 +51,7 @@ class SAMLConfiguration
 
     /**
      * @config
-     * @var array currently only `signatureAlgorithm` key is supported; see samlsettings yml config block for details
+     * @var array all keys supported except `requestedAuthnContext` (see AuthnContexts) ; see saml.yml config block for details
      */
     private static $Security;
 
@@ -210,7 +210,16 @@ class SAMLConfiguration
 
         // SECURITY SECTION
         $security = $config->get('Security');
+        $nameIdEncrypted = $security['nameIdEncrypted'];
+        $authnRequestsSigned = $security['authnRequestsSigned'];
+        $logoutRequestSigned = $security['logoutRequestSigned'];
+        $logoutResponseSigned = $security['logoutResponseSigned'];
+        $signMetadata = $security['signMetadata'];
+        $wantMessagesSigned = $security['wantMessagesSigned'];
+        $wantAssertionsSigned = $security['wantAssertionsSigned'];
+        $wantNameIdEncrypted = $security['wantNameIdEncrypted'];
         $signatureAlgorithm = $security['signatureAlgorithm'];
+        $wantXMLValidation = $security['wantXMLValidation'];
 
         $authnContexts = $config->get('authn_contexts');
         $disableAuthnContexts = $config->get('disable_authn_contexts');
@@ -231,25 +240,25 @@ class SAMLConfiguration
         $samlConf['security'] = [
             /** signatures and encryptions offered */
             // Indicates that the nameID of the <samlp:logoutRequest> sent by this SP will be encrypted.
-            'nameIdEncrypted' => true,
+            'nameIdEncrypted' => $nameIdEncrypted,
             // Indicates whether the <samlp:AuthnRequest> messages sent by this SP will be signed. [Metadata of the
             // SP will offer this info]
-            'authnRequestsSigned' => true,
+            'authnRequestsSigned' => $authnRequestsSigned,
             // Indicates whether the <samlp:logoutRequest> messages sent by this SP will be signed.
-            'logoutRequestSigned' => true,
+            'logoutRequestSigned' => $logoutRequestSigned,
             // Indicates whether the <samlp:logoutResponse> messages sent by this SP will be signed.
-            'logoutResponseSigned' => true,
-            'signMetadata' => false,
+            'logoutResponseSigned' => $logoutResponseSigned,
+            'signMetadata' => $signMetadata,
             /** signatures and encryptions required **/
             // Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest>
             // and <samlp:LogoutResponse> elements received by this SP to be signed.
-            'wantMessagesSigned' => false,
+            'wantMessagesSigned' => $wantMessagesSigned,
             // Indicates a requirement for the <saml:Assertion> elements received by
             // this SP to be signed. [Metadata of the SP will offer this info]
-            'wantAssertionsSigned' => true,
+            'wantAssertionsSigned' => $wantAssertionsSigned,
             // Indicates a requirement for the NameID received by
             // this SP to be encrypted.
-            'wantNameIdEncrypted' => false,
+            'wantNameIdEncrypted' => $wantNameIdEncrypted,
 
             // Algorithm that the toolkit will use on signing process. Options:
             //  - 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
@@ -269,7 +278,7 @@ class SAMLConfiguration
 
             // Indicates if the SP will validate all received xmls.
             // (In order to validate the xml, 'strict' and 'wantXMLValidation' must be true).
-            'wantXMLValidation' => true,
+            'wantXMLValidation' => $wantXMLValidation,
         ];
 
         return $samlConf;


### PR DESCRIPTION
## Description
Related:
Original PR - #71  (broke this old one in to two new PR's due to ss5 and ss6 releases)
SS6 PR - #76 


Without creating a brand new `MySAMLConfiguration` there was no easy way to edit the Security config on `SilverStripe\SAML\Services\SAMLConfiguration`

We could already do this for `signatureAlgorithm` so why not all?

You can now edit all values via yml except for `requestedAuthnContext`

```yaml
SilverStripe\SAML\Services\SAMLConfiguration:
  Security:
    nameIdEncrypted: true
    authnRequestsSigned: true
    logoutRequestSigned: true
    logoutResponseSigned: true
    signMetadata: false
    wantMessagesSigned: false
    wantAssertionsSigned: true
    wantNameIdEncrypted: false
    signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
    wantXMLValidation: true
```

## Issues
#72 
- #
