### PR TITLE
Fix PHP8.4 Deprecations for null types

### DIFF
--- a/src/Authenticators/SAMLAuthenticator.php
+++ b/src/Authenticators/SAMLAuthenticator.php
@@ -43,7 +43,7 @@ class SAMLAuthenticator extends MemberAuthenticator
      * @see SAMLLoginForm
      * @see SAMLMiddleware
      */
-    public function authenticate(array $data, HTTPRequest $request, ValidationResult &$result = null)
+    public function authenticate(array $data, HTTPRequest $request, ?ValidationResult &$result = null)
     {
         return null;
     }

--- a/src/Helpers/SAMLHelper.php
+++ b/src/Helpers/SAMLHelper.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SAML\Helpers;
 
 use Exception;
+use OneLogin\Saml2\Auth;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -13,7 +14,6 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\SAML\Authenticators\SAMLLoginHandler;
 use SilverStripe\SAML\Control\SAMLController;
 use SilverStripe\SAML\Services\SAMLConfiguration;
-use OneLogin\Saml2\Auth;
 
 /**
  * Class SAMLHelper
@@ -62,7 +62,7 @@ class SAMLHelper
      * @see SAMLController::acs() How the response is processed after the user is returned from the IdP
      * @return void This function will never return via normal control flow (see above).
      */
-    public function redirect(RequestHandler $requestHandler = null, HTTPRequest $request = null, $backURL = null)
+    public function redirect(?RequestHandler $requestHandler = null, ?HTTPRequest $request = null, $backURL = null)
     {
         // $data is not used - the form is just one button, with no fields.
         $auth = $this->getSAMLAuth();


### PR DESCRIPTION
Currently on the SAMLHelper and SAMLAuthenticator class, there are some PHP 8.4 deprecations thrown for - 

"Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead"

This pull request resolves those depreications.

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
